### PR TITLE
Add feature to stop searching in the hit callback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hankcs</groupId>
     <artifactId>aho-corasick-double-array-trie</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 
     <name>AhoCorasickDoubleArrayTrie</name>
     <url>https://github.com/hankcs/AhoCorasickDoubleArrayTrie</url>

--- a/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
+++ b/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
@@ -114,6 +114,32 @@ public class AhoCorasickDoubleArrayTrie<V> implements Serializable
      * @param text The text
      * @param processor A processor which handles the output
      */
+    public void parseText(String text, IHitCancellable<V> processor)
+    {
+        int currentState = 0;
+        for (int i = 0; i < text.length(); i++)
+        {
+            final int position = i + 1;
+            currentState = getState(currentState, text.charAt(i));
+            int[] hitArray = output[currentState];
+            if (hitArray != null)
+            {
+                for (int hit : hitArray)
+                {
+                    boolean proceed = processor.hit(position - l[hit], position, v[hit]);
+                    if(!proceed) {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse text
+     * @param text The text
+     * @param processor A processor which handles the output
+     */
     public void parseText(char[] text, IHit<V> processor)
     {
         int position = 1;
@@ -243,6 +269,21 @@ public class AhoCorasickDoubleArrayTrie<V> implements Serializable
          * @param index the index of the value assigned to the keyword, you can use the integer as a perfect hash value
          */
         void hit(int begin, int end, V value, int index);
+    }
+
+    /**
+     * Callback that allows to cancel the search process.
+     */
+    public interface IHitCancellable<V>
+    {
+        /**
+         * Hit a keyword, you can use some code like text.substring(begin, end) to get the keyword
+         * @param begin the beginning index, inclusive.
+         * @param end   the ending index, exclusive.
+         * @param value the value assigned to the keyword
+         * @return Return true for continuing the search and false for stopping it.
+         */
+        boolean hit(int begin, int end, V value);
     }
 
     /**

--- a/src/test/java/TestAhoCorasickDoubleArrayTrie.java
+++ b/src/test/java/TestAhoCorasickDoubleArrayTrie.java
@@ -68,6 +68,7 @@ public class TestAhoCorasickDoubleArrayTrie extends TestCase
         List<AhoCorasickDoubleArrayTrie<String>.Hit<String>> wordList = acdat.parseText(text);
         System.out.println(wordList);
     }
+
     public void testBuildAndParseSimply() throws Exception
     {
         AhoCorasickDoubleArrayTrie<String> acdat = buildASimpleAhoCorasickDoubleArrayTrie();
@@ -99,6 +100,52 @@ public class TestAhoCorasickDoubleArrayTrie extends TestCase
                 assertEquals(text.substring(begin, end), value);
             }
         });
+    }
+
+    private static class CountHits implements AhoCorasickDoubleArrayTrie.IHitCancellable<String> {
+        private int count;
+        private boolean countAll;
+
+        CountHits(boolean countAll) {
+            this.count = 0;
+            this.countAll = countAll;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        @Override
+        public boolean hit(int begin, int end, String value) {
+            count += 1;
+            return countAll;
+        }
+    }
+
+    public void testCancellation() throws Exception {
+        // Collect test data set
+        TreeMap<String, String> map = new TreeMap<String, String>();
+        String[] keyArray = new String[]
+                {
+                        "foo",
+                        "bar"
+                };
+        for (String key : keyArray)
+        {
+            map.put(key, key);
+        }
+        // Build an AhoCorasickDoubleArrayTrie
+        AhoCorasickDoubleArrayTrie<String> acdat = new AhoCorasickDoubleArrayTrie<String>();
+        acdat.build(map);
+        // count matches
+        String haystack = "sfwtfoowercwbarqwrcq";
+        CountHits cancellingMatcher = new CountHits(false);
+        CountHits countingMatcher = new CountHits(true);
+        System.out.println("Testing cancellation");
+        acdat.parseText(haystack, cancellingMatcher);
+        acdat.parseText(haystack, countingMatcher);
+        assertEquals(cancellingMatcher.count, 1);
+        assertEquals(countingMatcher.count, 2);
     }
 
     private String loadText(String path) throws IOException


### PR DESCRIPTION
When one is only interested whether there exists a match, it is wasteful to enumerate all matches. This pull request adds a new type of hit callback that allows stopping the search.