### PR TITLE
Fixed StackOverflowError for long keywords

### DIFF
--- a/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
+++ b/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
@@ -883,11 +883,28 @@ public class AhoCorasickDoubleArrayTrie<V> implements Serializable
         /**
          * insert the siblings to double array trie
          *
-         * @param siblings the siblings being inserted
-         * @return the position to insert them
+         * @param firstSiblings the initial siblings being inserted
          */
-        private int insert(List<Map.Entry<Integer, State>> siblings)
+        private void insert(List<Map.Entry<Integer, State>> firstSiblings)
         {
+            Queue<Map.Entry<Integer, List<Map.Entry<Integer, State>>>> siblingQueue = new ArrayDeque<Map.Entry<Integer, List<Map.Entry<Integer, State>>>>();
+            siblingQueue.add(new AbstractMap.SimpleEntry<Integer, List<Map.Entry<Integer, State>>>(null, firstSiblings));
+            
+            while (siblingQueue.isEmpty() == false)
+            {
+                insert(siblingQueue);
+            }
+        }
+
+        /**
+         * insert the siblings to double array trie
+         *
+         * @param siblingQueue a queue holding all siblings being inserted and the position to insert them
+         */
+        private void insert(Queue<Map.Entry<Integer, List<Map.Entry<Integer, State>>>> siblingQueue) {
+            Map.Entry<Integer, List<Map.Entry<Integer, State>>> tCurrent = siblingQueue.remove();
+            List<Map.Entry<Integer, State>> siblings = tCurrent.getValue();
+            
             int begin = 0;
             int pos = Math.max(siblings.get(0).getKey() + 1, nextCheckPos) - 1;
             int nonzero_num = 0;
@@ -962,12 +979,17 @@ public class AhoCorasickDoubleArrayTrie<V> implements Serializable
                 }
                 else
                 {
-                    int h = insert(new_siblings);   // dfs
-                    base[begin + sibling.getKey()] = h;
+                    siblingQueue.add(new AbstractMap.SimpleEntry<Integer, List<Map.Entry<Integer, State>>>(begin + sibling.getKey(), new_siblings));
                 }
                 sibling.getValue().setIndex(begin + sibling.getKey());
             }
-            return begin;
+
+            // Insert siblings
+            Integer parentBaseIndex = tCurrent.getKey();
+            if (parentBaseIndex != null)
+            {
+                base[parentBaseIndex] = begin;
+            }
         }
 
         /**

--- a/src/test/java/TestAhoCorasickDoubleArrayTrie.java
+++ b/src/test/java/TestAhoCorasickDoubleArrayTrie.java
@@ -19,6 +19,8 @@
  */
 
 import com.hankcs.algorithm.AhoCorasickDoubleArrayTrie;
+import com.hankcs.algorithm.AhoCorasickDoubleArrayTrie.Hit;
+
 import junit.framework.TestCase;
 import org.ahocorasick.trie.Trie;
 
@@ -73,6 +75,33 @@ public class TestAhoCorasickDoubleArrayTrie extends TestCase
     {
         AhoCorasickDoubleArrayTrie<String> acdat = buildASimpleAhoCorasickDoubleArrayTrie();
         validateASimpleAhoCorasickDoubleArrayTrie(acdat);
+    }
+
+    public void testBuildVeryLongWord() throws Exception
+    {
+        TreeMap<String, String> map = new TreeMap<String, String>();
+
+        int longWordLength = 20000;
+
+        String word = loadText("cn/text.txt");
+        map.put(word.substring(10, longWordLength), word.substring(10, longWordLength));
+        map.put(word.substring(30, 40), null);
+
+        word = loadText("en/text.txt");
+        map.put(word.substring(10, longWordLength), word.substring(10, longWordLength));
+        map.put(word.substring(30, 40), null);
+
+        // Build an AhoCorasickDoubleArrayTrie
+        AhoCorasickDoubleArrayTrie<String> acdat = new AhoCorasickDoubleArrayTrie<String>();
+        acdat.build(map);
+        
+        List<Hit<String>> result = acdat.parseText(word);
+        
+        assertEquals(2, result.size());
+        assertEquals(30, result.get(0).begin);
+        assertEquals(40, result.get(0).end);
+        assertEquals(10, result.get(1).begin);
+        assertEquals(longWordLength, result.get(1).end);
     }
 
     public void testBuildAndParseWithBigFile() throws Exception


### PR DESCRIPTION
When handling very long keywords the recursive nature of the replaced code produced a StackOverflowError.
I replaced the recursion with a Queue.