### PR TITLE
Fix requesting very big array.

### DIFF
--- a/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
+++ b/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
@@ -938,8 +938,10 @@ public class AhoCorasickDoubleArrayTrie<V> implements Serializable
                 if (allocSize <= (begin + siblings.get(siblings.size() - 1).getKey()))
                 {
                     // progress can be zero // 防止progress产生除零错误
-                    double l = (1.05 > 1.0 * keySize / (progress + 1)) ? 1.05 : 1.0 * keySize / (progress + 1);
-                    resize((int) (allocSize * l));
+                    double toSize = Math.max(1.05, 1.0 * keySize / (progress + 1)) * allocSize;
+                    double maxSize = Integer.MAX_VALUE * 0.95;
+                    if (allocSize >= maxSize) throw new RuntimeException("Double array trie is too big.");
+                    else resize((int) Math.min(toSize, maxSize));
                 }
 
                 if (used[begin])

--- a/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
+++ b/src/main/java/com/hankcs/algorithm/AhoCorasickDoubleArrayTrie.java
@@ -939,7 +939,7 @@ public class AhoCorasickDoubleArrayTrie<V> implements Serializable
                 {
                     // progress can be zero // 防止progress产生除零错误
                     double toSize = Math.max(1.05, 1.0 * keySize / (progress + 1)) * allocSize;
-                    double maxSize = Integer.MAX_VALUE * 0.95;
+                    int maxSize = (int) (Integer.MAX_VALUE * 0.95);
                     if (allocSize >= maxSize) throw new RuntimeException("Double array trie is too big.");
                     else resize((int) Math.min(toSize, maxSize));
                 }


### PR DESCRIPTION
When the number of keywords is enormous, will request a big array which beyond the JVM limit.
It should request at most `INT_MAX * 0.95` size array and throw an Exception when the required size is bigger than this size.

It fixed the issue: https://github.com/hankcs/AhoCorasickDoubleArrayTrie/issues/47
