### PR TITLE
Support Java 9 Platform Module System (JPMS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
                     <excludes>
                         <exclude>**/*.properties</exclude>
                     </excludes>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.hankcs.aho.corasic.doublearray.trie</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <!-- 单元测试插件 -->


### PR DESCRIPTION
The automatic-module-name contains the reserved word "array", making this library unusable by projects using the new Java 9 Platform Module System (JPMS).
Giving the project a hard coded and valid automatic-module-name makes this library compatible with Java 9 and up, and does not brake current Java 1.6 support.